### PR TITLE
Bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Fixed a bug that can cause a trap when attempting to access an already deleted position
+
 ## 1.1.0
 
 - Added `share/unshare()` interface to the class

--- a/README.md
+++ b/README.md
@@ -70,24 +70,29 @@ buf.len() // -> 2
 ### Build & test
 
 We need up-to-date versions of `node`, `moc` and `mops` installed.
-Suppose `<path-to-moc>` is the path of the `moc` binary of the appropriate version.
-
 Then run:
 ```
 git clone git@github.com:research-ag/swb.git
 mops install
-DFX_MOC_PATH=<path-to-moc> mops test
+mops test
 ```
+
+To run with a specific version of `moc` you can:
+
+* run `mocv` to select the version beforehand, or
+* use  `DFX_MOC_PATH=<path-to-moc> mops test`.
 
 ## Benchmark
 
-We measured the number of instructions for the `add`, `delete and `getOpt` operations as follows (compared to a plain Vector):
+We measured the number of instructions for the `add`, `delete` and `getOpt` operations as follows (compared to a plain Vector):
 
 |method|swb|vector|
 |---|---|---|
-|add|398|291|
-|delete|160|-|
-|getOpt|332|230|
+|add|486|330|
+|delete|176|-|
+|getOpt|405|261|
+
+The measurement was done with `dfx 0.15.2`, `moc 0.10.2` and with the `"optimize" : "cycles"` option in dfx.json.
 
 ## Copyright
 

--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swb"
-version = "1.1.0"
+version = "1.1.1"
 description = "Sliding window buffer with random access"
 repository = "https://github.com/research-ag/swb"
 keywords = [ "buffer", "sliding", "window", "queue" ]

--- a/src/lib.mo
+++ b/src/lib.mo
@@ -227,7 +227,6 @@ module {
       let limit = s >> (bits >> 1);
       if (d > limit) {
         old := ?new;
-        i_old := i_new;
         new := Vector<X>();
         i_new := i_old + size;
       };
@@ -241,6 +240,7 @@ module {
       if (end_ > end()) Prim.trap("index out of bounds in SlidingWindowBuffer.deleteTo");
       if (end_ >= i_new) {
         old := null;
+        i_old := i_new;
         new.deleteTo(end_ - i_new : Nat);
         rotateIfNeeded();
       } else if (end_ >= i_old) {

--- a/src/lib.mo
+++ b/src/lib.mo
@@ -227,8 +227,9 @@ module {
       let limit = s >> (bits >> 1);
       if (d > limit) {
         old := ?new;
+        i_old := i_new;
         new := Vector<X>();
-        i_new := i_old + size;
+        i_new += size;
       };
     };
 
@@ -239,15 +240,16 @@ module {
     public func deleteTo(end_ : Nat) {
       if (end_ > end()) Prim.trap("index out of bounds in SlidingWindowBuffer.deleteTo");
       if (end_ >= i_new) {
-        old := null;
-        i_old := i_new;
         new.deleteTo(end_ - i_new : Nat);
         rotateIfNeeded();
-      } else if (end_ >= i_old) {
-        switch (old) {
-          case (?vec) { vec.deleteTo(end_ - i_old : Nat) };
-          case (_) { Prim.trap("cannot happen") };
+        // free old is possible
+        if (end_ >= i_new) {
+          old := null;
+          i_old := i_new;
         };
+      } else if (end_ >= i_old) {
+        let ?vec = old else Prim.trap("cannot happen");
+        vec.deleteTo(end_ - i_old : Nat);
       };
     };
 

--- a/test/swb.test.mo
+++ b/test/swb.test.mo
@@ -124,7 +124,7 @@ do {
   for (i in Iter.range(1, N)) {
     ignore buf.add(i);
   };
-  buf.delete(N); // this will cause rotation if N >= 2
+  buf.delete(N); // this will cause rotation if N >= 2, set old to null
   assert buf.getOpt(0) == null;
   buf.deleteTo(N); // this will set old to null
   assert buf.getOpt(0) == null;

--- a/test/swb.test.mo
+++ b/test/swb.test.mo
@@ -116,3 +116,19 @@ do {
     assert buf1.getOpt(i) == (if (i < 50) { null } else { ?i });
   };
 };
+
+// Test access and deletion after rotation
+do {
+  let buf = SWB.SlidingWindowBuffer<Nat>();
+  let N = 2;
+  for (i in Iter.range(1, N)) {
+    ignore buf.add(i);
+  };
+  buf.delete(N); // this will cause rotation if N >= 2
+  assert buf.getOpt(0) == null;
+  buf.deleteTo(N); // this will set old to null
+  assert buf.getOpt(0) == null;
+  buf.deleteTo(0);
+  buf.deleteTo(1);
+  buf.deleteTo(2);
+};


### PR DESCRIPTION
There was when attempting to access elements in the old vector that were already deleted. The problem was the `i_old` value was not kept in sync with the old vector being null.

This PR fixes that and also frees the old vector a little bit earlier in some cases if its content is meant to be deleted.